### PR TITLE
Rama HU1 vFinal2.0

### DIFF
--- a/src/main/java/com/kevin/emazon/domain/usecase/CategoryUseCase.java
+++ b/src/main/java/com/kevin/emazon/domain/usecase/CategoryUseCase.java
@@ -5,15 +5,19 @@ import com.kevin.emazon.domain.model.Category;
 
 import com.kevin.emazon.domain.spi.ICategoryPersistentPort;
 import com.kevin.emazon.infraestructure.exceptions.CategoryException;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
+
+
 
 import java.util.Optional;
 
-@AllArgsConstructor
-@Component
+
 public class CategoryUseCase implements ICategoryServicePort {
     private final ICategoryPersistentPort categoryPersistentPort;
+
+    public CategoryUseCase(ICategoryPersistentPort categoryPersistentPort) {
+        this.categoryPersistentPort = categoryPersistentPort;
+    }
+
     @Override
     public Iterable<Category> getCategories() {
         // not necessary yet

--- a/src/main/java/com/kevin/emazon/infraestructure/adapter/CategoryJpaAdapter.java
+++ b/src/main/java/com/kevin/emazon/infraestructure/adapter/CategoryJpaAdapter.java
@@ -33,7 +33,7 @@ public class CategoryJpaAdapter implements ICategoryPersistentPort {
         if (categoryRepository.existsByNameIgnoreCase(category.getName())){
             throw new CategoryException("Categoría ya creada");
         }
-        categoryRepository.save(categoryRepository.save(categoryEntityMapper.categoryToCategoryEntity(category)));
+        categoryRepository.save(categoryEntityMapper.categoryToCategoryEntity(category));
     }
 
     @Override

--- a/src/main/java/com/kevin/emazon/infraestructure/config/ConfigurationClass.java
+++ b/src/main/java/com/kevin/emazon/infraestructure/config/ConfigurationClass.java
@@ -1,0 +1,16 @@
+package com.kevin.emazon.infraestructure.config;
+
+import com.kevin.emazon.domain.api.ICategoryServicePort;
+import com.kevin.emazon.domain.spi.ICategoryPersistentPort;
+import com.kevin.emazon.domain.usecase.CategoryUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ConfigurationClass {
+
+    @Bean
+    public ICategoryServicePort categoryServicePort(ICategoryPersistentPort categoryPersistentPort) {
+        return new CategoryUseCase(categoryPersistentPort);
+    }
+}

--- a/src/main/java/com/kevin/emazon/infraestructure/config/HandlerExceptionController.java
+++ b/src/main/java/com/kevin/emazon/infraestructure/config/HandlerExceptionController.java
@@ -1,4 +1,4 @@
-package com.kevin.emazon.infraestructure.rest.advice;
+package com.kevin.emazon.infraestructure.config;
 
 import com.kevin.emazon.application.dto.ExceptionResponseDto;
 import com.kevin.emazon.infraestructure.exceptions.CategoryException;

--- a/src/main/java/com/kevin/emazon/infraestructure/controllers/controllers/CategoryController.java
+++ b/src/main/java/com/kevin/emazon/infraestructure/controllers/controllers/CategoryController.java
@@ -1,4 +1,4 @@
-package com.kevin.emazon.infraestructure.rest.controllers;
+package com.kevin.emazon.infraestructure.controllers.controllers;
 
 import com.kevin.emazon.application.dto.CategoryDto;
 import com.kevin.emazon.application.handler.ICategoryHandler;

--- a/src/test/java/com/kevin/emazon/domain/usecase/CategoryUseCaseTest.java
+++ b/src/test/java/com/kevin/emazon/domain/usecase/CategoryUseCaseTest.java
@@ -3,28 +3,22 @@ package com.kevin.emazon.domain.usecase;
 import com.kevin.emazon.domain.model.Category;
 import com.kevin.emazon.domain.spi.ICategoryPersistentPort;
 import com.kevin.emazon.infraestructure.exceptions.CategoryException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class CategoryUseCaseTest {
-
     @Mock
     private ICategoryPersistentPort categoryPersistentPort;
 
     @InjectMocks
     private CategoryUseCase categoryUseCase;
-
-    @BeforeEach
-    void setUp() {
-
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     void saveCategory_ShouldThrowException_WhenCategoryIsInvalid() {

--- a/src/test/java/com/kevin/emazon/infraestructure/adapter/CategoryJpaAdapterTest.java
+++ b/src/test/java/com/kevin/emazon/infraestructure/adapter/CategoryJpaAdapterTest.java
@@ -1,18 +1,20 @@
 package com.kevin.emazon.infraestructure.adapter;
+
 import com.kevin.emazon.domain.model.Category;
 import com.kevin.emazon.infraestructure.entity.CategoryEntity;
 import com.kevin.emazon.infraestructure.exceptions.CategoryException;
 import com.kevin.emazon.infraestructure.mapper.ICategoryEntityMapper;
 import com.kevin.emazon.infraestructure.repositories.CategoryRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class CategoryJpaAdapterTest {
 
     @Mock
@@ -24,16 +26,11 @@ class CategoryJpaAdapterTest {
     @InjectMocks
     private CategoryJpaAdapter categoryJpaAdapter;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
     void saveCategory_ShouldThrowException_WhenCategoryAlreadyExists() {
         // Arrange
         Category category = new Category();
-        category.setName("Libro");
+        category.setName("Piza");
 
         when(categoryRepository.existsByNameIgnoreCase(category.getName())).thenReturn(true);
 


### PR DESCRIPTION
Cambios sugeridos por el administrador de la comunidad de discord implementados: 1. Se soluciona la advertencia en los test 2. Se eliminan las etiquetas de Spring en la capa de DOMAIN para pasar a crear una clase @Configuration para declarar las implementaciones de los @Bean ahí 4. En general se cambian clases de lugar y se eliminan paquetes inecesarios